### PR TITLE
remove execution from account handling

### DIFF
--- a/indexprotocol/accounts/protocol.go
+++ b/indexprotocol/accounts/protocol.go
@@ -130,11 +130,7 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 				}
 			}
 		case *action.Execution:
-			if dst != "" && act.Amount().Sign() > 0 {
-				if err := p.updateAccountHistory(tx, epochNumber, height, actionHash, dst, src, act.Amount().String()); err != nil {
-					return errors.Wrapf(err, "failed to update account history on height %d", height)
-				}
-			}
+			// balance changes from execution are handled in state-tracker version of iotex-core
 		case *action.DepositToRewardingFund:
 			if act.Amount().Sign() > 0 {
 				if err := p.updateAccountHistory(tx, epochNumber, height, actionHash, "", src, act.Amount().String()); err != nil {

--- a/indexprotocol/accounts/protocol.go
+++ b/indexprotocol/accounts/protocol.go
@@ -129,8 +129,6 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 					return errors.Wrapf(err, "failed to update account history on height %d", height)
 				}
 			}
-		case *action.Execution:
-			// balance changes from execution are handled in state-tracker version of iotex-core
 		case *action.DepositToRewardingFund:
 			if act.Amount().Sign() > 0 {
 				if err := p.updateAccountHistory(tx, epochNumber, height, actionHash, "", src, act.Amount().String()); err != nil {


### PR DESCRIPTION
Tranfers from execution are handled in state-tracker version of iotex-core.