### PR TITLE
remove getCandidates, refactor, fixed a bug

### DIFF
--- a/indexprotocol/rewards/protocol.go
+++ b/indexprotocol/rewards/protocol.go
@@ -158,8 +158,8 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 			return errors.Wrapf(err, "failed to update candidates in epoch %d", epochNumber)
 		}
 	}
-	if height == epochHeight {
-		if err := p.rebuildAccountRewardTable(tx, epochNumber-1); err != nil {
+	if height == epochHeight && epochNumber >= 3 {
+		if err := p.rebuildAccountRewardTable(tx, epochNumber-2); err != nil {
 			return errors.Wrap(err, "failed to rebuild account reward table")
 		}
 	}
@@ -361,9 +361,6 @@ func (p *Protocol) updateCandidateRewardAddress(
 }
 
 func (p *Protocol) rebuildAccountRewardTable(tx *sql.Tx, lastEpoch uint64) error {
-	if lastEpoch == 0 {
-		return nil
-	}
 	// Get voting result from last epoch
 	rewardAddrToNameMapping, weightedVotesMapping, err := p.getVotingInfo(lastEpoch)
 	if err != nil {

--- a/indexprotocol/rewards/protocol.go
+++ b/indexprotocol/rewards/protocol.go
@@ -372,17 +372,9 @@ func (p *Protocol) rebuildAccountRewardTable(tx *sql.Tx, lastEpoch uint64) error
 	// Get aggregate reward	records from last epoch
 	getQuery := fmt.Sprintf("SELECT epoch_number, reward_address, SUM(block_reward), SUM(epoch_reward), SUM(foundation_bonus) "+
 		"FROM %s WHERE epoch_number = ? GROUP BY epoch_number, reward_address", RewardHistoryTableName)
-
-	db := p.Store.GetDB()
-	stmt, err := db.Prepare(getQuery)
+	rows, err := tx.Query(getQuery, lastEpoch)
 	if err != nil {
-		return errors.Wrap(err, "failed to prepare get query")
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.Query(lastEpoch)
-	if err != nil {
-		return errors.Wrap(err, "failed to execute get query")
+		return errors.Wrap(err, "failed to get reward history query")
 	}
 
 	var aggregateReward AggregateReward
@@ -450,7 +442,7 @@ func (p *Protocol) getVotingInfo(tx *sql.Tx, lastEpoch uint64) (map[string][]str
 	getQuery := fmt.Sprintf("SELECT * FROM %s WHERE epoch_number = ?", votings.VotingResultTableName)
 	rows, err := tx.Query(getQuery, lastEpoch)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to execute get query")
+		return nil, nil, errors.Wrap(err, "failed to get voting result query")
 	}
 
 	var votingResult votings.VotingResult

--- a/indexprotocol/rewards/protocol.go
+++ b/indexprotocol/rewards/protocol.go
@@ -361,8 +361,8 @@ func (p *Protocol) updateCandidateRewardAddress(
 }
 
 func (p *Protocol) rebuildAccountRewardTable(tx *sql.Tx, lastEpoch uint64) error {
-	if lastEpoch == 0 {	
-		return nil	
+	if lastEpoch == 0 {
+		return nil
 	}
 	// Get voting result from last epoch
 	rewardAddrToNameMapping, weightedVotesMapping, err := p.getVotingInfo(tx, lastEpoch)

--- a/indexprotocol/votings/protocol.go
+++ b/indexprotocol/votings/protocol.go
@@ -23,7 +23,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/iotexproject/iotex-core/action/protocol/poll"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-election/carrier"
 	"github.com/iotexproject/iotex-election/committee"
@@ -127,15 +126,15 @@ func NewProtocol(store s.Store, numDelegates uint64, numSubEpochs uint64, gravit
 	}
 	voteThreshold, ok := new(big.Int).SetString(pollCfg.VoteThreshold, 10)
 	if !ok {
-		log.L().Error("Invalid vote threshold")
+		return nil, errors.New("Invalid vote threshold")
 	}
 	scoreThreshold, ok := new(big.Int).SetString(pollCfg.ScoreThreshold, 10)
 	if !ok {
-		log.L().Error("Invalid score threshold")
+		return nil, errors.New("Invalid score threshold")
 	}
 	selfStakingThreshold, ok := new(big.Int).SetString(pollCfg.SelfStakingThreshold, 10)
 	if !ok {
-		log.L().Error("Invalid self staking threshold")
+		return nil, errors.New("Invalid self staking threshold")
 	}
 	return &Protocol{
 		Store:                     store,

--- a/indexprotocol/votings/protocol.go
+++ b/indexprotocol/votings/protocol.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/iotexproject/iotex-core/action/protocol/poll"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-election/carrier"
 	"github.com/iotexproject/iotex-election/committee"
@@ -126,15 +127,15 @@ func NewProtocol(store s.Store, numDelegates uint64, numSubEpochs uint64, gravit
 	}
 	voteThreshold, ok := new(big.Int).SetString(pollCfg.VoteThreshold, 10)
 	if !ok {
-		return nil, errors.New("Invalid vote threshold")
+		log.L().Error("Invalid vote threshold")
 	}
 	scoreThreshold, ok := new(big.Int).SetString(pollCfg.ScoreThreshold, 10)
 	if !ok {
-		return nil, errors.New("Invalid score threshold")
+		log.L().Error("Invalid score threshold")
 	}
 	selfStakingThreshold, ok := new(big.Int).SetString(pollCfg.SelfStakingThreshold, 10)
 	if !ok {
-		return nil, errors.New("Invalid self staking threshold")
+		log.L().Error("Invalid self staking threshold")
 	}
 	return &Protocol{
 		Store:                     store,
@@ -490,7 +491,7 @@ func (p *Protocol) updateVotingTables(tx *sql.Tx, epochNumber uint64, height uin
 }
 
 func (p *Protocol) updateAggregateVoting(tx *sql.Tx, result *types.ElectionResult, epochNumber uint64) (err error) {
-	//update aggregate voting table 
+	//update aggregate voting table
 	votes := result.Votes()
 	sumOfWeightedVotes := make(map[aggregateKey]*big.Int)
 	totalVoted := big.NewInt(0)
@@ -529,7 +530,7 @@ func (p *Protocol) updateAggregateVoting(tx *sql.Tx, result *types.ElectionResul
 			return err
 		}
 	}
-	//update voting meta table 
+	//update voting meta table
 	delegates := result.Delegates()
 	totalWeighted := big.NewInt(0)
 	for _, cand := range delegates {
@@ -542,7 +543,7 @@ func (p *Protocol) updateAggregateVoting(tx *sql.Tx, result *types.ElectionResul
 		len(delegates),
 		totalWeighted.Text(10),
 	); err != nil {
-		return errors.Wrap(err, "failed to update voting meta table")	
+		return errors.Wrap(err, "failed to update voting meta table")
 	}
 	return
 }

--- a/indexprotocol/votings/protocol_test.go
+++ b/indexprotocol/votings/protocol_test.go
@@ -9,7 +9,6 @@ package votings
 import (
 	"context"
 	"database/sql"
-	"math/big"
 	"testing"
 	"time"
 
@@ -75,25 +74,6 @@ func TestProtocol(t *testing.T) {
 		Data: byteutil.Uint64ToBytes(uint64(1000)),
 	}, nil)
 
-	electionClient.EXPECT().GetCandidates(gomock.Any(), gomock.Any()).Times(1).Return(
-		&api.CandidateResponse{
-			Candidates: []*api.Candidate{
-				{
-					Name:               "616c6661",
-					OperatorAddress:    testutil.Addr1,
-					RewardAddress:      testutil.RewardAddr1,
-					TotalWeightedVotes: big.NewInt(1000).String(),
-				},
-				{
-					Name:               "627261766f",
-					OperatorAddress:    testutil.Addr2,
-					RewardAddress:      testutil.RewardAddr2,
-					TotalWeightedVotes: big.NewInt(500).String(),
-				},
-			},
-		}, nil,
-	)
-
 	timestamp, err := ptypes.TimestampProto(time.Unix(1000, 0))
 	require.NoError(err)
 
@@ -133,9 +113,4 @@ func TestProtocol(t *testing.T) {
 		return p.HandleBlock(ctx, tx, blk)
 	}))
 
-	votingResult, err := p.getVotingResult(uint64(1), "627261766f")
-	require.NoError(err)
-	require.Equal(testutil.Addr2, votingResult.OperatorAddress)
-	require.Equal(testutil.RewardAddr2, votingResult.RewardAddress)
-	require.Equal("500", votingResult.TotalWeightedVotes)
 }

--- a/indexservice/indexer.go
+++ b/indexservice/indexer.go
@@ -168,10 +168,6 @@ func (idx *Indexer) RegisterDefaultProtocols() error {
 	if err != nil {
 		log.L().Error("failed to make new voting protocol", zap.Error(err))
 	}
-	// in order of register protocol, voting protocol should be earlier than reward protocol 
-	if err := idx.RegisterProtocol(votings.ProtocolID, votingsProtocol); err != nil {
-		return errors.Wrap(err, "failed to register votings protocol")
-	}
 	if err := idx.RegisterProtocol(blocks.ProtocolID, blocksProtocol); err != nil {
 		return errors.Wrap(err, "failed to register blocks protocol")
 	}
@@ -180,6 +176,9 @@ func (idx *Indexer) RegisterDefaultProtocols() error {
 	}
 	if err := idx.RegisterProtocol(rewards.ProtocolID, rewardsProtocol); err != nil {
 		return errors.Wrap(err, "failed to register rewards protocol")
+	}
+	if err := idx.RegisterProtocol(votings.ProtocolID, votingsProtocol); err != nil {
+		return errors.Wrap(err, "failed to register votings protocol")
 	}
 	return idx.RegisterProtocol(accounts.ProtocolID, accountsProtocol)
 }

--- a/indexservice/indexer.go
+++ b/indexservice/indexer.go
@@ -168,6 +168,10 @@ func (idx *Indexer) RegisterDefaultProtocols() error {
 	if err != nil {
 		log.L().Error("failed to make new voting protocol", zap.Error(err))
 	}
+	// in order of register protocol, voting protocol should be earlier than reward protocol 
+	if err := idx.RegisterProtocol(votings.ProtocolID, votingsProtocol); err != nil {
+		return errors.Wrap(err, "failed to register votings protocol")
+	}
 	if err := idx.RegisterProtocol(blocks.ProtocolID, blocksProtocol); err != nil {
 		return errors.Wrap(err, "failed to register blocks protocol")
 	}
@@ -176,9 +180,6 @@ func (idx *Indexer) RegisterDefaultProtocols() error {
 	}
 	if err := idx.RegisterProtocol(rewards.ProtocolID, rewardsProtocol); err != nil {
 		return errors.Wrap(err, "failed to register rewards protocol")
-	}
-	if err := idx.RegisterProtocol(votings.ProtocolID, votingsProtocol); err != nil {
-		return errors.Wrap(err, "failed to register votings protocol")
 	}
 	return idx.RegisterProtocol(accounts.ProtocolID, accountsProtocol)
 }

--- a/indexservice/indexer.go
+++ b/indexservice/indexer.go
@@ -178,7 +178,7 @@ func (idx *Indexer) RegisterDefaultProtocols() error {
 		return errors.Wrap(err, "failed to register rewards protocol")
 	}
 	if err := idx.RegisterProtocol(votings.ProtocolID, votingsProtocol); err != nil {
-		return errors.Wrap(err, "failed to register accounts protocol")
+		return errors.Wrap(err, "failed to register votings protocol")
 	}
 	return idx.RegisterProtocol(accounts.ProtocolID, accountsProtocol)
 }

--- a/queryprotocol/actions/protocol_test.go
+++ b/queryprotocol/actions/protocol_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-analytics/indexprotocol"
 	"github.com/iotexproject/iotex-analytics/indexservice"
 	s "github.com/iotexproject/iotex-analytics/sql"
 	"github.com/iotexproject/iotex-analytics/testutil"
@@ -41,6 +42,11 @@ func TestProtocol(t *testing.T) {
 
 	// Creating protocol
 	var cfg indexservice.Config
+	cfg.Poll = indexprotocol.Poll{
+		VoteThreshold:        "100000000000000000000",
+		ScoreThreshold:       "0",
+		SelfStakingThreshold: "0",
+	}
 	idx := indexservice.NewIndexer(store, cfg)
 	p := NewProtocol(idx)
 

--- a/queryprotocol/chainmeta/protocol_test.go
+++ b/queryprotocol/chainmeta/protocol_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-analytics/indexprotocol"
 	"github.com/iotexproject/iotex-analytics/indexservice"
 	s "github.com/iotexproject/iotex-analytics/sql"
 	"github.com/iotexproject/iotex-analytics/testutil"
@@ -34,6 +35,11 @@ func TestProtocol_MostRecentTPS(t *testing.T) {
 	}()
 
 	var cfg indexservice.Config
+	cfg.Poll = indexprotocol.Poll{
+		VoteThreshold:        "100000000000000000000",
+		ScoreThreshold:       "0",
+		SelfStakingThreshold: "0",
+	}
 	idx := indexservice.NewIndexer(store, cfg)
 	p := NewProtocol(idx)
 


### PR DESCRIPTION
1. added native height to gravity height table
2. removed getCandidates API and moved updateResult() into rebuildVotingTables()
3. because rewards rebuilding is using voting_result table, to be compatible with this change, delayed the reward rebuilding at epoch-2 not epoch-1. 
4. Also, there was a bug when rebuild voting_meta(calculate total_weighted) and fixed it  

I'm planning to merge with native buckets on the rebuildVotingTables()
