### PR TITLE
Bug in parseVariables in GraphQL 117

### DIFF
--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -916,9 +916,9 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 					argsMap[arg.Name].Raw = value
 				}
 			case "Int":
-				valueJson, ok := val.Variables[arg.Name].(json.Number)
+				valueJSON, ok := val.Variables[arg.Name].(json.Number)
 				if ok {
-					value, err := valueJson.Int64()
+					value, err := valueJSON.Int64()
 					if err != nil {
 						return
 					}

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -899,14 +899,16 @@ func parseFieldArguments(ctx context.Context, fieldName string, selectedFieldNam
 	for _, arg := range arguments {
 		argsMap[arg.Name] = arg.Value
 	}
-	// TODO: Temporarily disable parsing variables
-	//parseVariables(ctx, argsMap, arguments)
+	parseVariables(ctx, argsMap, arguments)
 	return argsMap
 }
 func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, arguments ast.ArgumentList) {
 	val := graphql.GetRequestContext(ctx)
 	if val != nil {
 		for _, arg := range arguments {
+			if arg == nil {
+				continue
+			}
 			switch arg.Value.ExpectedType.Name() {
 			case "String":
 				value, ok := val.Variables[arg.Name].(string)
@@ -914,11 +916,14 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 					argsMap[arg.Name].Raw = value
 				}
 			case "Int":
-				value, err := val.Variables[arg.Name].(json.Number).Int64()
-				if err != nil {
-					return
+				valueJson, ok := val.Variables[arg.Name].(json.Number)
+				if ok {
+					value, err := valueJson.Int64()
+					if err != nil {
+						return
+					}
+					argsMap[arg.Name].Raw = fmt.Sprintf("%d", value)
 				}
-				argsMap[arg.Name].Raw = fmt.Sprintf("%d", value)
 			default:
 				return
 			}

--- a/queryprotocol/rewards/protocol.go
+++ b/queryprotocol/rewards/protocol.go
@@ -33,7 +33,7 @@ const (
 	selectVotingResult  = "SELECT epoch_number, total_weighted_votes FROM %s WHERE epoch_number >= ? AND epoch_number <= ? AND delegate_name = ?"
 	selectAccountReward = "SELECT epoch_number, epoch_reward, foundation_bonus FROM %s " +
 		"WHERE epoch_number >= ?  AND epoch_number <= ? AND candidate_name= ? "
-	selectAggregateVoting    = "SELECT epoch_number, voter_address, aggregate_votes FROM %s WHERE epoch_number >= ? AND epoch_number <= ? AND candidate_name=?"
+	selectAggregateVoting    = "SELECT epoch_number, candidate_name, voter_address, aggregate_votes FROM %s WHERE epoch_number >= ? AND epoch_number <= ? AND candidate_name=?"
 	selectAccountRewardIn    = "SELECT * FROM %s WHERE (epoch_number, candidate_name) IN (%s)"
 	selectVotingResultAll    = "SELECT * FROM %s WHERE epoch_number >= ?  AND epoch_number <= ? AND reward_address= ? "
 	selectAggregateVotingIn  = "SELECT * FROM %s WHERE (epoch_number, candidate_name) IN (%s)"
@@ -454,8 +454,8 @@ func (p *Protocol) voterVotes(startEpoch uint64, endEpoch uint64, delegateName s
 		return nil, errors.Wrap(err, "failed to execute get query")
 	}
 
-	var votingHistory votings.VotingInfo
-	parsedRows, err := s.ParseSQLRows(rows, &votingHistory)
+	var aggregateVoting votings.AggregateVoting
+	parsedRows, err := s.ParseSQLRows(rows, &aggregateVoting)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse results")
 	}
@@ -466,11 +466,11 @@ func (p *Protocol) voterVotes(startEpoch uint64, endEpoch uint64, delegateName s
 
 	epochToVoters := make(map[uint64]map[string]*big.Int)
 	for _, parsedRow := range parsedRows {
-		voting := parsedRow.(*votings.VotingInfo)
+		voting := parsedRow.(*votings.AggregateVoting)
 		if _, ok := epochToVoters[voting.EpochNumber]; !ok {
 			epochToVoters[voting.EpochNumber] = make(map[string]*big.Int)
 		}
-		weightedVotesInt, errs := stringToBigInt(voting.WeightedVotes)
+		weightedVotesInt, errs := stringToBigInt(voting.AggregateVotes)
 		if errs != nil {
 			return nil, errors.Wrap(errs, "failed to convert to big int")
 


### PR DESCRIPTION
test good for this query:
delegate(startEpoch: 1, epochCount: 10, delegateName: "iosg") {
    bookkeeping(percentage: 90, includeFoundationBonus: true) {
      rewardDistribution{
        voterEthAddress
      }
      count
    }
  }

fix another bug about table aggregate_voting