### PR TITLE
handle epoch number=1 issue to get native mint time

### DIFF
--- a/indexprotocol/votings/protocol.go
+++ b/indexprotocol/votings/protocol.go
@@ -396,15 +396,18 @@ func (p *Protocol) GetBucketInfoByEpoch(epochNum uint64, delegateName string) ([
 	if !ok {
 		return nil, errors.Errorf("Unexpected type %s", reflect.TypeOf(valueOfTime))
 	}
-	nativeMintTime, err := p.getLatestNativeMintTime(height)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get latest native mint time")
+	nativeMintTime := time.Time{}
+	if epochNum != 1 {
+		nativeMintTime, err = p.getLatestNativeMintTime(height)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get latest native mint time")
+		}
 	}
 	for i, vote := range votes {
 		candName := hex.EncodeToString(vote.Candidate())
 		if candName == delegateName {
 			mintTime := nativeMintTime
-			if !voteFlag[i] {
+			if !voteFlag[i] || epochNum == 1 {
 				mintTime = ethMintTime
 			}
 			votinginfo := &VotingInfo{


### PR DESCRIPTION
In case that epoch number is 1, there is no data to get native mint time, so we should handle this corner case. 
works on #137 