### PR TITLE
Store history of kick-out status and add API to query the statistics 177

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.1
 	github.com/iotexproject/iotex-core v0.8.1-0.20191007232750-b79fb5c7ebaa
 	github.com/iotexproject/iotex-election v0.2.7-0.20191008203349-58450eac6656
-	github.com/iotexproject/iotex-proto v0.2.5
+	github.com/iotexproject/iotex-proto v0.2.6-0.20200313212651-3c29eadd68ba
 	github.com/pkg/errors v0.8.1
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/iotexproject/iotex-proto v0.2.1-0.20190814190638-f74c55ffedf5 h1:iHfM
 github.com/iotexproject/iotex-proto v0.2.1-0.20190814190638-f74c55ffedf5/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/iotexproject/iotex-proto v0.2.5 h1:SYdl9Lqb0LYfFf3sfw92fN8GY3bthfCvGmltz+2uvDQ=
 github.com/iotexproject/iotex-proto v0.2.5/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.6-0.20200313212651-3c29eadd68ba h1:06z8oNwLjs9ap/q4tE9ORx9r2zkccoeWfklGcG1Fk+8=
+github.com/iotexproject/iotex-proto v0.2.6-0.20200313212651-3c29eadd68ba/go.mod h1:xKA4yUbg208k1j3+t10Pe7IzT6uHcP+/4rsDanF4Q58=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -158,11 +158,12 @@ type ComplexityRoot struct {
 	}
 
 	Delegate struct {
-		Bookkeeping  func(childComplexity int, percentage int, includeFoundationBonus bool) int
-		BucketInfo   func(childComplexity int) int
-		Productivity func(childComplexity int) int
-		Reward       func(childComplexity int) int
-		Staking      func(childComplexity int) int
+		Bookkeeping           func(childComplexity int, percentage int, includeFoundationBonus bool) int
+		BucketInfo            func(childComplexity int) int
+		KickoutHistoricalRate func(childComplexity int) int
+		Productivity          func(childComplexity int) int
+		Reward                func(childComplexity int) int
+		Staking               func(childComplexity int) int
 	}
 
 	DelegateAmount struct {
@@ -934,6 +935,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Delegate.BucketInfo(childComplexity), true
+
+	case "Delegate.KickoutHistoricalRate":
+		if e.complexity.Delegate.KickoutHistoricalRate == nil {
+			break
+		}
+
+		return e.complexity.Delegate.KickoutHistoricalRate(childComplexity), true
 
 	case "Delegate.Productivity":
 		if e.complexity.Delegate.Productivity == nil {
@@ -1879,6 +1887,7 @@ type Delegate {
     bookkeeping(percentage: Int!, includeFoundationBonus: Boolean!): Bookkeeping
     bucketInfo: BucketInfoOutput
     staking: StakingOutput
+    kickoutHistoricalRate: String!
 }
 
 type StakingOutput{
@@ -4872,6 +4881,33 @@ func (ec *executionContext) _Delegate_staking(ctx context.Context, field graphql
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalOStakingOutput2ᚖgithubᚗcomᚋiotexprojectᚋiotexᚑanalyticsᚋgraphqlᚐStakingOutput(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Delegate_kickoutHistoricalRate(ctx context.Context, field graphql.CollectedField, obj *Delegate) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Delegate",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.KickoutHistoricalRate, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _DelegateAmount_delegateName(ctx context.Context, field graphql.CollectedField, obj *DelegateAmount) graphql.Marshaler {
@@ -9216,6 +9252,11 @@ func (ec *executionContext) _Delegate(ctx context.Context, sel ast.SelectionSet,
 			out.Values[i] = ec._Delegate_bucketInfo(ctx, field, obj)
 		case "staking":
 			out.Values[i] = ec._Delegate_staking(ctx, field, obj)
+		case "kickoutHistoricalRate":
+			out.Values[i] = ec._Delegate_kickoutHistoricalRate(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalid = true
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -120,11 +120,12 @@ type Chain struct {
 }
 
 type Delegate struct {
-	Reward       *Reward           `json:"reward"`
-	Productivity *Productivity     `json:"productivity"`
-	Bookkeeping  *Bookkeeping      `json:"bookkeeping"`
-	BucketInfo   *BucketInfoOutput `json:"bucketInfo"`
-	Staking      *StakingOutput    `json:"staking"`
+	Reward                *Reward           `json:"reward"`
+	Productivity          *Productivity     `json:"productivity"`
+	Bookkeeping           *Bookkeeping      `json:"bookkeeping"`
+	BucketInfo            *BucketInfoOutput `json:"bucketInfo"`
+	Staking               *StakingOutput    `json:"staking"`
+	KickoutHistoricalRate string            `json:"kickoutHistoricalRate"`
 }
 
 type DelegateAmount struct {

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -207,7 +207,16 @@ func (r *queryResolver) Delegate(ctx context.Context, startEpoch int, epochCount
 	if containField(requestedFields, "staking") {
 		g.Go(func() error { return r.getStaking(delegateResponse, startEpoch, epochCount, delegateName) })
 	}
+	if containField(requestedFields, "kickoutHistoricalRate") {
+		g.Go(func() error { return r.kickoutHistoricalRate(delegateResponse, startEpoch, epochCount, delegateName) })
+	}
 	return delegateResponse, g.Wait()
+}
+
+// kickoutHistoricalRate handles the kickout rate
+func (r *queryResolver) kickoutHistoricalRate(delegateResponse *Delegate, startEpoch int, epochCount int, delegateName string) (err error) {
+	delegateResponse.KickoutHistoricalRate, err = r.VP.GetKickoutHistoricalRate(startEpoch, epochCount, delegateName)
+	return
 }
 
 // Voting handles voting requests

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -63,6 +63,7 @@ type Delegate {
     bookkeeping(percentage: Int!, includeFoundationBonus: Boolean!): Bookkeeping
     bucketInfo: BucketInfoOutput
     staking: StakingOutput
+    kickoutHistoricalRate: String!
 }
 
 type StakingOutput{

--- a/indexprotocol/votings/kickoutlist.go
+++ b/indexprotocol/votings/kickoutlist.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2020 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package votings
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/go-pkgs/byteutil"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+)
+
+const (
+	// KickoutListTableName is the table name of kickout list
+	KickoutListTableName = "kickout_list"
+	// EpochAddressIndexName is the index name of epoch number and address on kickout table
+	EpochAddressIndexName = "epoch_address_index"
+	createKickoutList     = "CREATE TABLE IF NOT EXISTS %s " +
+		"(epoch_number DECIMAL(65, 0) NOT NULL,intensity_rate DECIMAL(65, 0) NOT NULL,address VARCHAR(41) NOT NULL, count DECIMAL(65, 0) NOT NULL,PRIMARY KEY (`epoch_number`, `address`), UNIQUE KEY %s (epoch_number, address))"
+	insertKickoutList = "INSERT IGNORE INTO %s (epoch_number,intensity_rate,address,count) VALUES (?, ?, ?, ?)"
+)
+
+type (
+	// KickoutList defines the schema of "kickout_list" table
+	KickoutList struct {
+		EpochNumber   uint64
+		IntensityRate uint64
+		Address       string
+		Count         uint64
+	}
+)
+
+func (p *Protocol) createKickoutListTable(tx *sql.Tx) error {
+	if _, err := tx.Exec(fmt.Sprintf(createKickoutList, KickoutListTableName, EpochAddressIndexName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Protocol) updateKickoutListTable(cli iotexapi.APIServiceClient, epochNum uint64, tx *sql.Tx) error {
+	kickoutList, err := p.getKickoutList(cli, epochNum)
+	if err != nil {
+		return err
+	}
+	insertQuery := fmt.Sprintf(insertKickoutList, KickoutListTableName)
+	for _, k := range kickoutList.Blacklists {
+		if _, err := tx.Exec(insertQuery, epochNum, kickoutList.IntensityRate, k.Address, k.Count); err != nil {
+			return errors.Wrap(err, "failed to update kickout list table")
+		}
+	}
+	return nil
+}
+
+func (p *Protocol) getKickoutList(cli iotexapi.APIServiceClient, epochNum uint64) (*iotextypes.KickoutCandidateList, error) {
+	request := &iotexapi.ReadStateRequest{
+		ProtocolID: []byte("poll"),
+		MethodName: []byte("KickoutListByEpoch"),
+		Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+	}
+	out, err := cli.ReadState(context.Background(), request)
+	if err != nil {
+		return nil, err
+	}
+	pb := &iotextypes.KickoutCandidateList{}
+	if err := proto.Unmarshal(out.Data, pb); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal candidate")
+	}
+	return pb, nil
+}

--- a/indexprotocol/votings/protocol.go
+++ b/indexprotocol/votings/protocol.go
@@ -267,7 +267,7 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 			return errors.Wrapf(err, "failed to put data into voting tables in epoch %d", epochNumber)
 		}
 		if err := p.updateKickoutListTable(chainClient, epochNumber, tx); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to put data into kickout tables in epoch %d", epochNumber)
 		}
 	}
 	return nil

--- a/indexprotocol/votings/protocol.go
+++ b/indexprotocol/votings/protocol.go
@@ -250,9 +250,6 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 	epochNumber := p.epochCtx.GetEpochNumber(height)
 	indexCtx := indexcontext.MustGetIndexCtx(ctx)
 	if indexCtx.ConsensusScheme == "ROLLDPOS" && height == p.epochCtx.GetEpochHeight(epochNumber) {
-		if err := p.updateKickoutListTable(indexCtx.ChainClient, epochNumber, tx); err != nil {
-			return err
-		}
 		chainClient := indexCtx.ChainClient
 		electionClient := indexCtx.ElectionClient
 		var gravityHeight uint64
@@ -268,6 +265,9 @@ func (p *Protocol) HandleBlock(ctx context.Context, tx *sql.Tx, blk *block.Block
 		}
 		if err := p.putVotingTables(tx, electionClient, chainClient, epochNumber, height, gravityHeight); err != nil {
 			return errors.Wrapf(err, "failed to put data into voting tables in epoch %d", epochNumber)
+		}
+		if err := p.updateKickoutListTable(chainClient, epochNumber, tx); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/indexprotocol/votings/protocol_test.go
+++ b/indexprotocol/votings/protocol_test.go
@@ -74,7 +74,18 @@ func TestProtocol(t *testing.T) {
 		ElectionClient:  electionClient,
 		ConsensusScheme: "ROLLDPOS",
 	})
-	// first call KickoutListByEpoch
+
+	// first call GetGravityChainStartHeight
+	readStateRequestForGravityHeight := &iotexapi.ReadStateRequest{
+		ProtocolID: []byte(poll.ProtocolID),
+		MethodName: []byte("GetGravityChainStartHeight"),
+		Arguments:  [][]byte{byteutil.Uint64ToBytes(1)},
+	}
+	first := chainClient.EXPECT().ReadState(gomock.Any(), readStateRequestForGravityHeight).Times(1).Return(&iotexapi.ReadStateResponse{
+		Data: byteutil.Uint64ToBytes(uint64(1000)),
+	}, nil)
+
+	// second call KickoutListByEpoch
 	kickoutListByEpochRequest := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte(poll.ProtocolID),
 		MethodName: []byte("KickoutListByEpoch"),
@@ -82,18 +93,8 @@ func TestProtocol(t *testing.T) {
 	}
 	pb := &iotextypes.KickoutCandidateList{}
 	data, err := proto.Marshal(pb)
-	first := chainClient.EXPECT().ReadState(gomock.Any(), kickoutListByEpochRequest).Times(1).Return(&iotexapi.ReadStateResponse{
+	second := chainClient.EXPECT().ReadState(gomock.Any(), kickoutListByEpochRequest).Times(1).Return(&iotexapi.ReadStateResponse{
 		Data: data,
-	}, nil)
-
-	// second call GetGravityChainStartHeight
-	readStateRequestForGravityHeight := &iotexapi.ReadStateRequest{
-		ProtocolID: []byte(poll.ProtocolID),
-		MethodName: []byte("GetGravityChainStartHeight"),
-		Arguments:  [][]byte{byteutil.Uint64ToBytes(1)},
-	}
-	second := chainClient.EXPECT().ReadState(gomock.Any(), readStateRequestForGravityHeight).Times(1).Return(&iotexapi.ReadStateResponse{
-		Data: byteutil.Uint64ToBytes(uint64(1000)),
 	}, nil)
 	gomock.InOrder(
 		first,

--- a/queryprotocol/votings/protocol.go
+++ b/queryprotocol/votings/protocol.go
@@ -327,9 +327,6 @@ func (p *Protocol) getAppearingCount(db *sql.DB, startEpoch int, epochCount int,
 	}
 	defer stmt.Close()
 	if err = stmt.QueryRow(delegateName).Scan(&count); err != nil {
-		if err == sql.ErrNoRows {
-			return 0, indexprotocol.ErrNotExist
-		}
 		return 0, errors.Wrap(err, "failed to execute get query")
 	}
 	return

--- a/queryprotocol/votings/protocol.go
+++ b/queryprotocol/votings/protocol.go
@@ -289,12 +289,15 @@ func (p *Protocol) GetOperatorAddress(aliasName string) (string, error) {
 //GetKickoutHistoricalRate gets kickout rate
 func (p *Protocol) GetKickoutHistoricalRate(startEpoch int, epochCount int, delegateName string) (string, error) {
 	if _, ok := p.indexer.Registry.Find(votings.ProtocolID); !ok {
-		return "0", errors.New("votings protocol is unregistered")
+		return "", errors.New("votings protocol is unregistered")
 	}
 	db := p.indexer.Store.GetDB()
 	appearingCount, err := p.getAppearingCount(db, startEpoch, epochCount, delegateName)
 	if err != nil {
-		return "0", errors.New("get Kickout Count error")
+		return "0", errors.New("get Appearing Count error")
+	}
+	if appearingCount == 0 {
+		return "0", nil
 	}
 	kickoutCount := uint64(0)
 	for i := startEpoch; i < startEpoch+epochCount; i++ {
@@ -310,9 +313,6 @@ func (p *Protocol) GetKickoutHistoricalRate(startEpoch int, epochCount int, dele
 		if exist {
 			kickoutCount++
 		}
-	}
-	if appearingCount == 0 {
-		return "0", nil
 	}
 	rate := float64(kickoutCount) / float64(appearingCount)
 	return fmt.Sprintf("%0.2f", rate), nil


### PR DESCRIPTION
work on #177 

```
query {
  delegate(startEpoch:1,epochCount:5,delegateName:"00000064756361706974616c"){
	kickoutHistoricalRate
  }
}
```

need test iotex-core api when mainnet or testnet deployed KickoutListByEpoch api 