### PR TITLE
failed to get pagination parameters

### DIFF
--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -310,25 +310,25 @@ func (r *queryResolver) Xrc20(ctx context.Context) (*Xrc20, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	if containField(requestedFields, "byContractAddress") {
 		g.Go(func() error {
-			return r.getXrcByContractAddress(ctx, actionResponse, "xrc20")
+			return r.getXrcByContractAddress(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "byAddress") {
 		g.Go(func() error {
-			return r.getXrcByAddress(ctx, actionResponse, "xrc20")
+			return r.getXrcByAddress(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "byPage") {
 		g.Go(func() error {
-			return r.getXrcByPage(ctx, actionResponse, "xrc20")
+			return r.getXrcByPage(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "xrc20Addresses") {
-		g.Go(func() error { return r.getXrcAddresses(ctx, actionResponse, "xrc20") })
+		g.Go(func() error { return r.getXrcAddresses(ctx, actionResponse) })
 	}
 	if containField(requestedFields, "tokenHolderAddresses") {
 		g.Go(func() error {
-			return r.xrcTokenHolderAddresses(ctx, actionResponse, "xrc20")
+			return r.xrcTokenHolderAddresses(ctx, actionResponse)
 		})
 	}
 	return actionResponse, g.Wait()
@@ -342,25 +342,25 @@ func (r *queryResolver) Xrc721(ctx context.Context) (*Xrc721, error) {
 	g, ctx := errgroup.WithContext(ctx)
 	if containField(requestedFields, "byContractAddress") {
 		g.Go(func() error {
-			return r.getXrcByContractAddress(ctx, actionResponse, "xrc721")
+			return r.getXrcByContractAddress(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "byAddress") {
 		g.Go(func() error {
-			return r.getXrcByAddress(ctx, actionResponse, "xrc721")
+			return r.getXrcByAddress(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "byPage") {
 		g.Go(func() error {
-			return r.getXrcByPage(ctx, actionResponse, "xrc721")
+			return r.getXrcByPage(ctx, actionResponse)
 		})
 	}
 	if containField(requestedFields, "xrc721Addresses") {
-		g.Go(func() error { return r.getXrcAddresses(ctx, actionResponse, "xrc721") })
+		g.Go(func() error { return r.getXrcAddresses(ctx, actionResponse) })
 	}
 	if containField(requestedFields, "tokenHolderAddresses") {
 		g.Go(func() error {
-			return r.xrcTokenHolderAddresses(ctx, actionResponse, "xrc721")
+			return r.xrcTokenHolderAddresses(ctx, actionResponse)
 		})
 	}
 	return actionResponse, g.Wait()
@@ -794,8 +794,8 @@ func (r *queryResolver) getEvmTransfersByAddress(ctx context.Context, actionResp
 	return nil
 }
 
-func (r *queryResolver) getXrcByContractAddress(ctx context.Context, actionResponse interface{}, xrcType string) error {
-	argsMap := parseFieldArguments(ctx, "byContractAddress", xrcType)
+func (r *queryResolver) getXrcByContractAddress(ctx context.Context, actionResponse interface{}) error {
+	argsMap := parseFieldArguments(ctx, "byContractAddress", "")
 	address, err := getStringArg(argsMap, "address")
 	if err != nil {
 		return errors.Wrap(err, "failed to get address")
@@ -852,8 +852,8 @@ func (r *queryResolver) getXrcByContractAddress(ctx context.Context, actionRespo
 	return nil
 }
 
-func (r *queryResolver) getXrcByAddress(ctx context.Context, actionResponse interface{}, xrcType string) error {
-	argsMap := parseFieldArguments(ctx, "byAddress", xrcType)
+func (r *queryResolver) getXrcByAddress(ctx context.Context, actionResponse interface{}) error {
+	argsMap := parseFieldArguments(ctx, "byAddress", "")
 	address, err := getStringArg(argsMap, "address")
 	if err != nil {
 		return errors.Wrap(err, "failed to get address")
@@ -910,8 +910,8 @@ func (r *queryResolver) getXrcByAddress(ctx context.Context, actionResponse inte
 	return nil
 }
 
-func (r *queryResolver) xrcTokenHolderAddresses(ctx context.Context, actionResponse interface{}, xrcType string) error {
-	argsMap := parseFieldArguments(ctx, "tokenHolderAddresses", xrcType)
+func (r *queryResolver) xrcTokenHolderAddresses(ctx context.Context, actionResponse interface{}) error {
+	argsMap := parseFieldArguments(ctx, "tokenHolderAddresses", "addresses")
 	addr, err := getStringArg(argsMap, "tokenAddress")
 	if err != nil {
 		return errors.Wrap(err, "failed to get address")
@@ -958,8 +958,8 @@ func (r *queryResolver) xrcTokenHolderAddresses(ctx context.Context, actionRespo
 	return nil
 }
 
-func (r *queryResolver) getXrcByPage(ctx context.Context, actionResponse interface{}, xrcType string) error {
-	argsMap := parseFieldArguments(ctx, "byPage", xrcType)
+func (r *queryResolver) getXrcByPage(ctx context.Context, actionResponse interface{}) error {
+	argsMap := parseFieldArguments(ctx, "byPage", "")
 	paginationMap, err := getPaginationArgs(argsMap)
 	if err != nil {
 		return errors.Wrap(err, "failed to get pagination arguments for get xrc20 ByPage")
@@ -1010,8 +1010,17 @@ func (r *queryResolver) getXrcByPage(ctx context.Context, actionResponse interfa
 	return nil
 }
 
-func (r *queryResolver) getXrcAddresses(ctx context.Context, actionResponse interface{}, xrcType string) error {
-	argsMap := parseFieldArguments(ctx, "xrc20Addresses", xrcType)
+func (r *queryResolver) getXrcAddresses(ctx context.Context, actionResponse interface{}) (err error) {
+	var fieldName string
+	switch actionResponse.(type) {
+	case *Xrc721:
+		fieldName = "xrc721Addresses"
+	case *Xrc20:
+		fieldName = "xrc20Addresses"
+	default:
+		return errors.New("failed to convert type")
+	}
+	argsMap := parseFieldArguments(ctx, fieldName, "")
 	paginationMap, err := getPaginationArgs(argsMap)
 	if err != nil {
 		return errors.Wrap(err, "failed to get pagination arguments for get xrc20 addresses")


### PR DESCRIPTION
work on #178
fix the following api's paganation:

```
query {
  xrc20{
    tokenHolderAddresses(tokenAddress:"io14j96vg9pkx28htpgt2jx0tf3v9etpg4j9h384m") {
      count
      addresses(pagination:{first:2,skip:0})
      }
    }
}

query {
  xrc721{
    tokenHolderAddresses(tokenAddress:"io14j96vg9pkx28htpgt2jx0tf3v9etpg4j9h384m") {
      count
      addresses(pagination:{first:2,skip:0})
      }
    }
}

query {
  xrc20 {
    xrc20Addresses(pagination:{first:3,skip:1}) {
      exist
      count
      addresses
    }
  }
}

query {
  xrc721 {
    xrc721Addresses(pagination:{first:3,skip:1}) {
      exist
      count
      addresses
    }
  }
}
```