### PR TITLE
add monitor synced block height

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/iotexproject/iotex-election v0.2.11
 	github.com/iotexproject/iotex-proto v0.2.6-0.20200327040553-157f35632918
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/rs/zerolog v1.14.3
 	github.com/stretchr/testify v1.4.0
 	github.com/vektah/gqlparser v1.1.2

--- a/indexservice/indexer.go
+++ b/indexservice/indexer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
@@ -29,6 +30,16 @@ import (
 	"github.com/iotexproject/iotex-analytics/indexprotocol/votings"
 	"github.com/iotexproject/iotex-analytics/queryprotocol/chainmeta/chainmetautil"
 	s "github.com/iotexproject/iotex-analytics/sql"
+)
+
+var (
+	blockHeightMtc = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "block_height",
+			Help: "block height",
+		},
+		[]string{},
+	)
 )
 
 // Indexer handles the index build for blocks
@@ -85,6 +96,7 @@ func NewIndexer(store s.Store, cfg Config) *Indexer {
 
 // Start starts the indexer
 func (idx *Indexer) Start(ctx context.Context) error {
+	prometheus.MustRegister(blockHeightMtc)
 	indexCtx := indexcontext.MustGetIndexCtx(ctx)
 	chainClient := indexCtx.ChainClient
 
@@ -241,6 +253,7 @@ func (idx *Indexer) IndexInBatch(ctx context.Context, tipHeight uint64) error {
 			}
 			// Update lastHeight tracker
 			idx.lastHeight = blk.Height()
+			blockHeightMtc.With(prometheus.Labels{}).Set(float64(idx.lastHeight))
 		}
 		startHeight += count
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-election/pb/api"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
@@ -94,7 +95,7 @@ func main() {
 		CP: chainmeta.NewProtocol(idx),
 		HP: hermes2.NewProtocol(idx, cfg.HermesConfig),
 	}}))))
-
+	http.Handle("/metrics", promhttp.Handler())
 	log.S().Infof("connect to http://localhost:%s/ for GraphQL playground", port)
 
 	// Start GraphQL query service


### PR DESCRIPTION
url is the same as graphql,path /metrics,show block height like this:
![image](https://user-images.githubusercontent.com/5837417/82329529-07da6c80-9a14-11ea-979b-31db4d065843.png)
