### PR TITLE
fix change field.Arguments bug when using custom variables

### DIFF
--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -1528,7 +1528,7 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 				//     "skip": 4
 				// }
 				if ok {
-					var children ast.ChildValueList
+					argsMap[arg.Name] = &ast.Value{Children: ast.ChildValueList{}}
 					for k, v := range value {
 						valueJSON, ok := v.(json.Number)
 						if ok {
@@ -1537,10 +1537,7 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 								continue
 							}
 							child := &ast.ChildValue{Name: k, Value: &ast.Value{Raw: fmt.Sprintf("%d", valueInt64)}}
-							children = append(children, child)
-						}
-						argsMap[arg.Name] = &ast.Value{
-							Children: children,
+							argsMap[arg.Name].Children = append(argsMap[arg.Name].Children, child)
 						}
 					}
 				} else {
@@ -1552,7 +1549,7 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 					//     "f":2,
 					//     "s":4
 					// }
-					var children ast.ChildValueList
+					argsMap[arg.Name] = &ast.Value{Children: ast.ChildValueList{}}
 					for _, child := range arg.Value.Children {
 
 						value, ok := val.Variables[child.Value.Raw].(json.Number)
@@ -1565,11 +1562,8 @@ func parseVariables(ctx context.Context, argsMap map[string]*ast.Value, argument
 								Name:  child.Name,
 								Value: &ast.Value{Raw: fmt.Sprintf("%d", valueInt64)},
 							}
-							children = append(children, child)
+							argsMap[arg.Name].Children = append(argsMap[arg.Name].Children, child)
 						}
-					}
-					argsMap[arg.Name] = &ast.Value{
-						Children: children,
 					}
 				}
 			default:


### PR DESCRIPTION
### For [issue #266](https://github.com/iotexproject/iotex-analytics/issues/266)
### Fix bug for [pr #277](https://github.com/iotexproject/iotex-analytics/pull/277)

### Reason
Because there is a `lru cache` in package `github.com/99designs/gqlgen/graphql`.As I did in [pr#277](https://github.com/iotexproject/iotex-analytics/pull/277), I modified the data in `field.Arguments`, which is stored in the cache, resulting in the same data being parsed next time.If the datas in the cache have not been replaced, the subsequent query results will be the same as the first results.Using the new `ast.Value` for `argsMap` can solve this problem.

### Test Step:
1. Calling different API multiple times with different parameters to get `ResultA`.
2. Using sql statements corresponding to the first step directly in the database to get `ResultB`.
3. If `ResultA` is equal to `ResultB` , It works.